### PR TITLE
Handle empty query parameters attempts: Attempted to fix query parameter handling, see #2.

### DIFF
--- a/app/resources/note.py
+++ b/app/resources/note.py
@@ -100,10 +100,10 @@ class NoteList(MethodView):
         return note
 
     @jwt_required()
-    @note_blp.arguments(NoteListQuerySchema, location="query")
+    @note_blp.arguments(NoteListQuerySchema, location="query", validation=False)
     @note_blp.response(200, NoteListResponseSchema)
     def get(self, query_params):
-        query_params = NoteListQuerySchema().validate(request.args)
+        # query_params = NoteListQuerySchema().validate(request.args)
         print("Query Parameters (Before Loading):", query_params)
 
         schema = NoteListQuerySchema()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,6 @@
-from marshmallow import Schema, fields, validate
+from marshmallow import Schema, fields, validate, ValidationError
+
+v_error = ValidationError
 
 
 class UserSchema(Schema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -46,11 +46,11 @@ class NoteListResponseSchema(Schema):
 
 
 class NoteListQuerySchema(Schema):
-    page = fields.Int(missing=1)
-    per_page = fields.Int(missing=10)
-    sort_by = fields.Str()
-    order = fields.Str()
-    tag = fields.Str()
+    page = fields.Int(required=False)
+    per_page = fields.Int(required=False)
+    sort_by = fields.Str(required=False)
+    order = fields.Str(required=False)
+    tag = fields.Str(required=False)
 
 
 class NoteTagSchema(Schema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -46,8 +46,8 @@ class NoteListResponseSchema(Schema):
 
 
 class NoteListQuerySchema(Schema):
-    page = fields.Int()
-    per_page = fields.Int()
+    page = fields.Int(missing=1)
+    per_page = fields.Int(missing=10)
     sort_by = fields.Str()
     order = fields.Str()
     tag = fields.Str()


### PR DESCRIPTION
This pull request contains attempts made to resolve issue #2.

**Problem:** The issue was related to handling empty query parameters in the NoteList endpoint, which caused a "Not a valid integer" error.

**Attempts:** In this branch, we made several attempts to address the issue. These attempts include:
- Modifying the `NoteListQuerySchema` to use default values when query parameters are missing.
- Adjusting the `NoteList` endpoint to handle empty query parameters and provide meaningful default values.
- Implementing validation logic to catch and handle empty query parameters.

**Testing:** We conducted tests for each attempt to determine their effectiveness in resolving the issue. However, none of these attempts provided a complete solution.

**Related Changes:**
- Updated the `NoteListQuerySchema` and `NoteList` endpoint to test different approaches.

While these attempts did not fully resolve the issue, they are part of our process to identify the most effective solution. We have learned from these attempts and have since implemented a working solution in the "handle-empty-query-parameters" branch.

Please review these attempts for reference and historical context. However, the working solution is available in the "handle-empty-query-parameters" branch, and we recommend merging that branch to address the issue.

Thank you for your understanding.
